### PR TITLE
Handle model composition deeper than one level

### DIFF
--- a/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerType.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerType.scala
@@ -24,7 +24,12 @@ case class ScalaSwaggerType(name: String, props: List[ScalaSwaggerObject] = List
     }
   }
 
-  def isCompositeType(): Boolean = {
-    !props.isEmpty
+  def isCompositeType: Boolean = {
+    props.nonEmpty
+  }
+
+  override def toString = {
+    val propNames = props.map(_.getName())
+    s"ScalaSwaggerType(name=$name, props=$propNames)"
   }
 }


### PR DESCRIPTION
## Description
As a part of handling model composition:

- refactor `processResponseObjects`
- process `processComposedModel` should process all properties not just Terraform properties. 
- update `processModel` to drop all non-tf properties at the end (after the model (and all submodels) have been processed)
- new util method `getTerraformProperties` to extract Terraform properties from schema


## Testing
Ran `./bin/run.sh`