### PR TITLE
Fix test script

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,20 +2,114 @@
 
 set -e
 
-$GENERATOR_DIRECTORY/bin/run.sh $YAML_PATH
+# setup
+if [ $# -eq 0 ]; then
+  echo "================================================================"
+  echo "ERROR: Insufficient args"
+  echo "ERROR: Usage: ./bin/test.sh <yaml-file> [clone-dir-for-provider]"
+  echo "================================================================"
+  exit 1
+fi
 
-mv $GENERATOR_DIRECTORY/target/resources/*scheduled* $TF_SUMOLOGIC_PROVIDER/sumologic
+YAML_FILE="$1"
+TF_GENERATOR_DIR="$(dirname "$0")/.."
+TF_PROVIDER_CLONE_DIR=${2:-"/tmp"}
+TF_SUMOLOGIC_PROVIDER_DIR="$TF_PROVIDER_CLONE_DIR/terraform-provider-sumologic"
 
-mv $GENERATOR_DIRECTORY/target/resources/*role* $TF_SUMOLOGIC_PROVIDER/sumologic
 
-mv $GENERATOR_DIRECTORY/target/resources/*extraction* $TF_SUMOLOGIC_PROVIDER/sumologic
+validateDependencies() {
+  if ! [ -x "$(command -v terraform)" ]; then
+    echo "Terraform is not installed."
+    echo "See https://learn.hashicorp.com/terraform/getting-started/install.html"
+    exit 1
+  fi
 
-mv $GENERATOR_DIRECTORY/target/resources/*partition* $TF_SUMOLOGIC_PROVIDER/sumologic
+  if ! [ -x "$(command -v go)" ]; then
+    echo "golang is not installed."
+    echo "See https://golang.org/doc/install"
+    exit 1
+  fi
+}
 
-cd $TF_SUMOLOGIC_PROVIDER
+validateEnv() {
+  if [ ! -n "$SUMOLOGIC_ACCESSID" ]; then
+    echo "Env var 'SUMOLOGIC_ACCESSID' must be set"
+    exit 1
+  fi
 
-make fmt
+  if [ ! -n "$SUMOLOGIC_ACCESSKEY" ]; then
+    echo "Env var 'SUMOLOGIC_ACCESSID' must be set"
+    exit 1
+  fi
 
-make install
+  if [ ! -n "$SUMOLOGIC_BASE_URL" ]; then
+    echo "Env var 'SUMOLOGIC_BASE_URL' must be set"
+    echo "Set it to API server  e.g. for nite, set it to 'https://nite-api.sumologic.net/api/'"
+    exit 1
+  else
+    export SUMOLOGIC_ENVIRONMENT="us2"
+  fi
+}
 
-make testacc
+
+# generate provider files
+runGenerator() {
+  $TF_GENERATOR_DIR/bin/run.sh $YAML_FILE
+}
+
+# move generated files to terraform provider
+cloneProvider() {
+  echo "Cloning terraform-provider-sumologic repo in '$TF_SUMOLOGIC_PROVIDER_DIR'"
+  if [ ! -d $TF_SUMOLOGIC_PROVIDER_DIR ]; then
+    git clone https://github.com/terraform-providers/terraform-provider-sumologic --quiet $TF_SUMOLOGIC_PROVIDER_DIR
+  fi
+}
+
+setupProvider() {
+  rm -fr $TF_SUMOLOGIC_PROVIDER_DIR
+  mkdir -p $TF_PROVIDER_CLONE_DIR
+  cloneProvider
+  mv -vf $TF_GENERATOR_DIR/target/resources/resource_sumologic_*.go $TF_SUMOLOGIC_PROVIDER_DIR/sumologic
+  mv -vf $TF_GENERATOR_DIR/target/resources/sumologic_*.go $TF_SUMOLOGIC_PROVIDER_DIR/sumologic
+  mv -vf $TF_GENERATOR_DIR/target/resources/provider.go $TF_SUMOLOGIC_PROVIDER_DIR/sumologic
+}
+
+fmtProvider() {
+  cd $TF_SUMOLOGIC_PROVIDER_DIR
+  make fmt
+}
+
+runAcceptanceTests() {
+  echo "------------------------------------------------------------------------"
+  echo "Running Acceptance Tests"
+  echo "------------------------------------------------------------------------"
+  cd $TF_SUMOLOGIC_PROVIDER_DIR
+  make fmt
+  make install
+  make testacc
+  echo "------------------------------------------------------------------------"
+}
+
+# Runs tests for a particular resource.
+runResourceTests() {
+  cd $TF_SUMOLOGIC_PROVIDER_DIR/sumologic
+  resourceName=$1
+  echo "------------------------------------------------------------------------"
+  echo "Running Acceptance Tests for resource '$resourceName'"
+  echo "------------------------------------------------------------------------"
+  TF_ACC=1 go test -v -run TestAccSumologic${TF_RESOURCE_NAME}_basic
+  TF_ACC=1 go test -v -run TestAcc${TF_RESOURCE_NAME}_create
+  TF_ACC=1 go test -v -run TestAcc${TF_RESOURCE_NAME}_update
+  echo "------------------------------------------------------------------------"
+}
+
+
+validateDependencies && validateEnv
+
+if [ -n "$TF_RESOURCE_NAME" ]; then
+  # TF_RESOURCE_NAME must be set to same value same as x-tf-resource-name extension.
+  runGenerator && setupProvider && fmtProvider
+  runResourceTests $TF_RESOURCE_NAME
+else
+  runGenerator && setupProvider && runAcceptanceTests
+fi

--- a/src/main/scala/com/sumologic/terraform_generator/writer/ProviderFileGenerator.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/writer/ProviderFileGenerator.scala
@@ -68,7 +68,9 @@ case class ProviderFileGenerator(taggedApis: List[String])
       |	}
       |	location := resp.Header.Get("location")
       |	if location == "" {
-      |		return location, fmt.Errorf("location header not found")
+      |   // location header not found implies there was no redirect needed
+      |   // i.e, the desired environment is us1
+      |   return "https://api.sumologic.com/api/", nil
       |	}
       |	return strings.Split(location, "v1")[0], nil
       |}


### PR DESCRIPTION
- Take access key/id and url as env vars
- Add an optional argument to specify directory in which terraform provider will be cloned.
- Add a check for dependencies
- Add ability to run test for a resource via `TF_RESOURCE_NAME` env var.


Also updated `Provider.go` template to match what we have in the official provider.