### PR TITLE
Fixes for subdomain api

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -74,9 +74,15 @@ setupProvider() {
   mv -vf $TF_GENERATOR_DIR/target/resources/provider.go $TF_SUMOLOGIC_PROVIDER_DIR/sumologic
 }
 
+installGoImport() {
+  if ! [ -x "$(command -v go)" ]; then
+    go get golang.org/x/tools/cmd/goimports
+  fi
+}
+
 fmtProvider() {
   cd $TF_SUMOLOGIC_PROVIDER_DIR
-  make fmt
+  goimports -w sumologic
 }
 
 runAcceptanceTests() {
@@ -84,7 +90,6 @@ runAcceptanceTests() {
   echo "Running Acceptance Tests"
   echo "------------------------------------------------------------------------"
   cd $TF_SUMOLOGIC_PROVIDER_DIR
-  make fmt
   make install
   make testacc
   echo "------------------------------------------------------------------------"
@@ -104,12 +109,13 @@ runResourceTests() {
 }
 
 
-validateDependencies && validateEnv
+validateDependencies && validateEnv && installGoImport
+
+runGenerator && setupProvider && fmtProvider
 
 if [ -n "$TF_RESOURCE_NAME" ]; then
   # TF_RESOURCE_NAME must be set to same value same as x-tf-resource-name extension.
-  runGenerator && setupProvider && fmtProvider
   runResourceTests $TF_RESOURCE_NAME
 else
-  runGenerator && setupProvider && runAcceptanceTests
+  runAcceptanceTests
 fi

--- a/src/main/scala/com/sumologic/terraform_generator/TerraformGenerator.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/TerraformGenerator.scala
@@ -67,7 +67,8 @@ object TerraformGenerator
       val templates = OpenApiProcessor.process(openApi)
       templates.foreach {
         template =>
-          logger.info(s"write files for resource: '${template.sumoSwaggerClassName}'")
+          logger.info(s"Resource: '${template.sumoSwaggerClassName}' - " +
+              s"${template.supportedEndpoints.head.responses.head}")
           writeFiles(template, template.sumoSwaggerClassName)
       }
 

--- a/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerResponse.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerResponse.scala
@@ -8,4 +8,8 @@ case class ScalaSwaggerResponse(respTypeName: String, respTypeOpt: Option[ScalaS
       respTypeOpt.get.name
     }
   }
+
+  override def toString = {
+    s"ScalaSwaggerResponse(name=$respTypeName, respTypeOpt=$respTypeOpt)"
+  }
 }

--- a/src/main/scala/com/sumologic/terraform_generator/utils/ProcessorHelper.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/utils/ProcessorHelper.scala
@@ -78,6 +78,7 @@ trait ProcessorHelper
     }
   }
 
+  // FIXME: What is this method supposed to do? The arg `modelName` is not used.
   private def getTagForComponent(openAPI: OpenAPI, modelName: String): Map[String, (String, Schema[_])] = {
     openAPI.getComponents.getSchemas.asScala.map {
       case (name, schema) =>

--- a/src/main/scala/com/sumologic/terraform_generator/writer/TerraformClassFileGenerator.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/writer/TerraformClassFileGenerator.scala
@@ -37,12 +37,24 @@ case class TerraformClassFileGenerator(terraform: ScalaSwaggerTemplate)
           endpoint
         }
     }
+
     val endpoints = endpointsWithChangedNames.map {
-      case endpoint: ScalaSwaggerEndpoint =>
-        val bodyParams = endpoint.parameters.filter(_.paramType == TerraformSupportedParameterTypes.BodyParameter)
+      endpoint: ScalaSwaggerEndpoint =>
+        val bodyParams = endpoint.parameters.filter {
+          _.paramType == TerraformSupportedParameterTypes.BodyParameter
+        }
+
         if (bodyParams.size > 1 || endpoint.responses.filterNot(_.respTypeName.toLowerCase == "default").size > 1) {
-          val paramsToExclude = bodyParams.filterNot(_.param.getName.toLowerCase == terraform.sumoSwaggerClassName.toLowerCase)
-          val filteredEndpoint = endpoint.copy(parameters = endpoint.parameters diff paramsToExclude, responses = endpoint.responses.filter(_.respTypeName.toLowerCase == terraform.sumoSwaggerClassName.toLowerCase))
+          val paramsToExclude = bodyParams.filterNot {
+            _.param.getName().toLowerCase == terraform.sumoSwaggerClassName.toLowerCase
+          }
+
+          val filteredEndpoint = endpoint.copy(
+            parameters = endpoint.parameters diff paramsToExclude,
+            responses = endpoint.responses.filter {
+              _.respTypeName.toLowerCase == terraform.sumoSwaggerClassName.toLowerCase
+            }
+          )
           filteredEndpoint.terraformify(terraform) + "\n"
         } else {
           endpoint.terraformify(terraform) + "\n"
@@ -50,8 +62,8 @@ case class TerraformClassFileGenerator(terraform: ScalaSwaggerTemplate)
     }.mkString("")
 
     val types = typesUsed.map {
-      case stype: ScalaSwaggerType =>
-        stype.terraformify(terraform) + "\n"
+      sType: ScalaSwaggerType =>
+        sType.terraformify(terraform) + "\n"
     }.mkString("")
 
     s"// ---------- BEGIN ${terraform.sumoSwaggerClassName} ----------\n" + intro +


### PR DESCRIPTION
- Handle APIs that don't have id as path param
- Fix resource name in the Scala model object
- Refactor/reformat code
- Use goimports to format code instead of gofmt (to trim unused imports)