### PR TITLE
Fix code generation of test values for properties with pattern attribute

### DIFF
--- a/src/main/scala/com/sumologic/terraform_generator/writer/AcceptanceTestGeneratorHelper.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/writer/AcceptanceTestGeneratorHelper.scala
@@ -97,7 +97,11 @@ trait AcceptanceTestGeneratorHelper extends StringHelper {
 
   private def generateTestValueFromPattern(pattern: String): String = {
     val generator = new Xeger(pattern)
-    generator.generate()
-    s""""${generator.generate().replace(""""""", """\"""")}""""
+    // NOTE: Xeger doesn't support all valid regular expressions. A regex like "^(Opt1|opt2)$"
+    // would end up generating value like "^Opt1$" which doesn't work. Doing a fix locally till
+    // we fix all regular expressions in the yaml files.
+    // https://code.google.com/archive/p/xeger/wikis/XegerLimitations.wiki
+    val testValue = generator.generate().replace("^", "").replace("$", "")
+    s""""${testValue.replace(""""""", """\"""")}""""
   }
 }


### PR DESCRIPTION
 Xeger doesn't support all valid regular expressions (https://code.google.com/archive/p/xeger/wikis/XegerLimitations.wiki). A regex like `^(Opt1|opt2)$` would end up generating value like `^Opt1$` which doesn't work. Doing a fix locally till we fix all regular expressions in the yaml files. 

Ran mvn clean test.
Ran acceptance tests.